### PR TITLE
Fix msg_init typo in tests

### DIFF
--- a/rans_test.py
+++ b/rans_test.py
@@ -6,7 +6,7 @@ rng = np.random.RandomState(0)
 
 
 def test_rans():
-    x = rans.x_init
+    x = rans.msg_init
     scale_bits = 8
     starts = rng.randint(0, 256, size=1000)
     freqs = rng.randint(1, 256, size=1000) % (256 - starts)
@@ -31,7 +31,7 @@ def test_rans():
 
 
 def test_flatten_unflatten():
-    state = rans.x_init
+    state = rans.msg_init
     some_bits = rng.randint(1 << 8, size=5)
     for b in some_bits:
         state = rans.append(state, b, 1, 8)

--- a/torch_vae/torch_vae_binary_encode_test.py
+++ b/torch_vae/torch_vae_binary_encode_test.py
@@ -41,7 +41,7 @@ def test_bvae_enc_dec():
 
     # randomly generate some 'other' bits
     other_bits = rng.randint(1 << 16, size=20, dtype=np.uint32)
-    state = rans.x_init
+    state = rans.msg_init
     state = util.uniforms_append(16)(state, other_bits)
 
     # ---------------------------- ENCODE ------------------------------------
@@ -60,4 +60,4 @@ def test_bvae_enc_dec():
     #  recover the other bits from q(y|x_0)
     state, recovered_bits = util.uniforms_pop(16, 20)(state)
     assert all(other_bits == recovered_bits)
-    assert state == rans.x_init
+    assert state == rans.msg_init

--- a/util_test.py
+++ b/util_test.py
@@ -46,7 +46,7 @@ def test_binomial_cdf():
                       data_precision, precision)
 
 def check_append_pop(data, append, pop):
-    state = rans.x_init
+    state = rans.msg_init
 
     # Encode
     state = append(state, data)
@@ -56,7 +56,7 @@ def check_append_pop(data, append, pop):
     # Decode
     state, data_reconstructed = pop(state)
     np_testing.assert_allclose(data, data_reconstructed)
-    assert state == rans.x_init
+    assert state == rans.msg_init
 
 def test_uniform_append_pop():
     n_data = 100


### PR DESCRIPTION
Hey, @j-towns! I really enjoyed the your functional implementation of rANS.

There seems to be a typo (`"x_init"` instead of `"msg_init"`) breaking the tests. This PR should fix it.

Cheers.